### PR TITLE
Licence holder name + area display fixes

### DIFF
--- a/backend/src/print_request_detail/dto/create-print_request_detail.dto.ts
+++ b/backend/src/print_request_detail/dto/create-print_request_detail.dto.ts
@@ -16,6 +16,7 @@ export class CreatePrintRequestDetailDto extends PickType(
     "last_name",
     "legal_name",
     "licence_holder_name",
+    "mailing_address",
     "mailing_address_line_1",
     "mailing_address_line_2",
     "mailing_address_line_3",

--- a/backend/src/print_request_detail/dto/create-print_request_detail.dto.ts
+++ b/backend/src/print_request_detail/dto/create-print_request_detail.dto.ts
@@ -15,6 +15,7 @@ export class CreatePrintRequestDetailDto extends PickType(
     "middle_name",
     "last_name",
     "legal_name",
+    "licence_holder_name",
     "mailing_address_line_1",
     "mailing_address_line_2",
     "mailing_address_line_3",

--- a/backend/src/print_request_detail/dto/print_request_detail.dto.ts
+++ b/backend/src/print_request_detail/dto/print_request_detail.dto.ts
@@ -10,6 +10,7 @@ export class PrintRequestDetailDto {
   middle_name: string;
   last_name: string;
   legal_name: string;
+  licence_holder_name: string;
   mailing_address_line_1: string;
   mailing_address_line_2: string;
   mailing_address_line_3: string;

--- a/backend/src/print_request_detail/dto/print_request_detail.dto.ts
+++ b/backend/src/print_request_detail/dto/print_request_detail.dto.ts
@@ -11,6 +11,7 @@ export class PrintRequestDetailDto {
   last_name: string;
   legal_name: string;
   licence_holder_name: string;
+  mailing_address: string;
   mailing_address_line_1: string;
   mailing_address_line_2: string;
   mailing_address_line_3: string;

--- a/backend/src/print_request_detail/dto/update-print_request_detail.dto.ts
+++ b/backend/src/print_request_detail/dto/update-print_request_detail.dto.ts
@@ -16,6 +16,7 @@ export class UpdatePrintRequestDetailDto extends PickType(
     "last_name",
     "legal_name",
     "licence_holder_name",
+    "mailing_address",
     "mailing_address_line_1",
     "mailing_address_line_2",
     "mailing_address_line_3",

--- a/backend/src/print_request_detail/dto/update-print_request_detail.dto.ts
+++ b/backend/src/print_request_detail/dto/update-print_request_detail.dto.ts
@@ -15,6 +15,7 @@ export class UpdatePrintRequestDetailDto extends PickType(
     "middle_name",
     "last_name",
     "legal_name",
+    "licence_holder_name",
     "mailing_address_line_1",
     "mailing_address_line_2",
     "mailing_address_line_3",

--- a/backend/src/print_request_detail/print_request_detail.service.ts
+++ b/backend/src/print_request_detail/print_request_detail.service.ts
@@ -28,6 +28,7 @@ export class PrintRequestDetailService {
     newItem.middle_name = printRequestDetail.middle_name;
     newItem.last_name = printRequestDetail.last_name;
     newItem.legal_name = printRequestDetail.legal_name;
+    newItem.licence_holder_name = printRequestDetail.licence_holder_name;
     newItem.mailing_address_line_1 = printRequestDetail.mailing_address_line_1;
     newItem.mailing_address_line_2 = printRequestDetail.mailing_address_line_2;
     newItem.mailing_address_line_3 = printRequestDetail.mailing_address_line_3;
@@ -56,29 +57,6 @@ export class PrintRequestDetailService {
       );
     }
     newItem.mailing_address = mailingAddress;
-    let licenceHolderName = "";
-    if (
-      printRequestDetail.first_name ||
-      printRequestDetail.middle_name ||
-      printRequestDetail.last_name
-    ) {
-      if (printRequestDetail.first_name) {
-        licenceHolderName = printRequestDetail.first_name;
-      }
-      if (printRequestDetail.middle_name) {
-        licenceHolderName = licenceHolderName.concat(
-          " " + printRequestDetail.middle_name
-        );
-      }
-      if (printRequestDetail.last_name) {
-        licenceHolderName = licenceHolderName.concat(
-          " " + printRequestDetail.last_name
-        );
-      }
-    } else if (printRequestDetail.legal_name) {
-      licenceHolderName = printRequestDetail.legal_name;
-    }
-    newItem.licence_holder_name = licenceHolderName;
     let area_ha_number = "";
     let legal_description = "";
     if (JSON.parse(printRequestDetail.parcels)[0]) {

--- a/backend/src/print_request_detail/print_request_detail.service.ts
+++ b/backend/src/print_request_detail/print_request_detail.service.ts
@@ -57,18 +57,26 @@ export class PrintRequestDetailService {
     }
     newItem.mailing_address = mailingAddress;
     let licenceHolderName = "";
-    if (printRequestDetail.first_name) {
-      licenceHolderName = printRequestDetail.first_name;
-    }
-    if (printRequestDetail.middle_name) {
-      licenceHolderName = licenceHolderName.concat(
-        " " + printRequestDetail.middle_name
-      );
-    }
-    if (printRequestDetail.last_name) {
-      licenceHolderName = licenceHolderName.concat(
-        " " + printRequestDetail.last_name
-      );
+    if (
+      printRequestDetail.first_name ||
+      printRequestDetail.middle_name ||
+      printRequestDetail.last_name
+    ) {
+      if (printRequestDetail.first_name) {
+        licenceHolderName = printRequestDetail.first_name;
+      }
+      if (printRequestDetail.middle_name) {
+        licenceHolderName = licenceHolderName.concat(
+          " " + printRequestDetail.middle_name
+        );
+      }
+      if (printRequestDetail.last_name) {
+        licenceHolderName = licenceHolderName.concat(
+          " " + printRequestDetail.last_name
+        );
+      }
+    } else if (printRequestDetail.legal_name) {
+      licenceHolderName = printRequestDetail.legal_name;
     }
     newItem.licence_holder_name = licenceHolderName;
     let area_ha_number = "";

--- a/backend/src/print_request_detail/print_request_detail.service.ts
+++ b/backend/src/print_request_detail/print_request_detail.service.ts
@@ -29,6 +29,7 @@ export class PrintRequestDetailService {
     newItem.last_name = printRequestDetail.last_name;
     newItem.legal_name = printRequestDetail.legal_name;
     newItem.licence_holder_name = printRequestDetail.licence_holder_name;
+    newItem.mailing_address = printRequestDetail.mailing_address;
     newItem.mailing_address_line_1 = printRequestDetail.mailing_address_line_1;
     newItem.mailing_address_line_2 = printRequestDetail.mailing_address_line_2;
     newItem.mailing_address_line_3 = printRequestDetail.mailing_address_line_3;
@@ -42,21 +43,6 @@ export class PrintRequestDetailService {
     newItem.location_description = printRequestDetail.location_description;
     newItem.parcels = printRequestDetail.parcels;
     newItem.create_userid = printRequestDetail.create_userid;
-    let mailingAddress = "";
-    if (printRequestDetail.mailing_address_line_1) {
-      mailingAddress = printRequestDetail.mailing_address_line_1;
-    }
-    if (printRequestDetail.mailing_address_line_2) {
-      mailingAddress = mailingAddress.concat(
-        ", " + printRequestDetail.mailing_address_line_2
-      );
-    }
-    if (printRequestDetail.mailing_address_line_3) {
-      mailingAddress = mailingAddress.concat(
-        ", " + printRequestDetail.mailing_address_line_3
-      );
-    }
-    newItem.mailing_address = mailingAddress;
     let area_ha_number = "";
     let legal_description = "";
     if (JSON.parse(printRequestDetail.parcels)[0]) {

--- a/frontend/src/app.controller.ts
+++ b/frontend/src/app.controller.ts
@@ -112,7 +112,8 @@ export class AppController {
         documentTypes.push(entry.comments);
       }
     }
-    const primaryContactName = this.ttlsService.getPrimaryContactName(ttlsJSON);
+    const primaryContactName = ttlsJSON.licence_holder_name;
+    ttlsJSON["parcels"] = JSON.parse(ttlsJSON.parcels);
     const title =
       process.env.ticdi_environment == "DEVELOPMENT"
         ? "DEVELOPMENT - " + PAGE_TITLES.INDEX

--- a/frontend/src/ttls/ttls.service.ts
+++ b/frontend/src/ttls/ttls.service.ts
@@ -63,7 +63,10 @@ export class TTLSService {
         middle_name: printRequestDetail.tenantAddr.middleName,
         last_name: printRequestDetail.tenantAddr.lastName,
         legal_name: printRequestDetail.tenantAddr.legalName,
-        licence_holder_name: this.getPrimaryContactName(printRequestDetail),
+        licence_holder_name: this.getPrimaryContactName(
+          printRequestDetail.tenantAddr
+        ),
+        mailing_address: this.getMailingAddress(printRequestDetail.tenantAddr),
         mailing_address_line_1: printRequestDetail.tenantAddr.addrLine1,
         mailing_address_line_2: printRequestDetail.tenantAddr.addrLine2,
         mailing_address_line_3: printRequestDetail.tenantAddr.addrLine3,
@@ -131,30 +134,43 @@ export class TTLSService {
   }
 
   // returns the individual name and if there is none, then it returns the legal name
-  getPrimaryContactName(prdObject: {
-    tenantAddr: {
-      firstName: string;
-      middleName: string;
-      lastName: string;
-      legalName: string;
-    };
+  getPrimaryContactName(tenantAddr: {
+    firstName: string;
+    middleName: string;
+    lastName: string;
+    legalName: string;
   }) {
-    if (
-      prdObject.tenantAddr.firstName ||
-      prdObject.tenantAddr.middleName ||
-      prdObject.tenantAddr.lastName
-    ) {
+    if (tenantAddr.firstName || tenantAddr.middleName || tenantAddr.lastName) {
       return (
-        prdObject.tenantAddr.firstName +
+        tenantAddr.firstName +
         " " +
-        prdObject.tenantAddr.middleName +
+        tenantAddr.middleName +
         " " +
-        prdObject.tenantAddr.lastName
+        tenantAddr.lastName
       );
-    } else if (prdObject.tenantAddr.legalName) {
-      return prdObject.tenantAddr.legalName;
+    } else if (tenantAddr.legalName) {
+      return tenantAddr.legalName;
     }
     return "";
+  }
+
+  // if there are multiple addresses, concatenate them
+  getMailingAddress(tenantAddr: {
+    addrLine1: string;
+    addrLine2: string;
+    addrLine3: string;
+  }) {
+    let mailingAddress = "";
+    if (tenantAddr.addrLine1) {
+      mailingAddress = tenantAddr.addrLine1;
+    }
+    if (tenantAddr.addrLine2) {
+      mailingAddress = mailingAddress.concat(", " + tenantAddr.addrLine2);
+    }
+    if (tenantAddr.addrLine3) {
+      mailingAddress = mailingAddress.concat(", " + tenantAddr.addrLine3);
+    }
+    return mailingAddress;
   }
 
   callHttp(id: string): Observable<Array<Object>> {

--- a/frontend/src/ttls/ttls.service.ts
+++ b/frontend/src/ttls/ttls.service.ts
@@ -63,6 +63,7 @@ export class TTLSService {
         middle_name: printRequestDetail.tenantAddr.middleName,
         last_name: printRequestDetail.tenantAddr.lastName,
         legal_name: printRequestDetail.tenantAddr.legalName,
+        licence_holder_name: this.getPrimaryContactName(printRequestDetail),
         mailing_address_line_1: printRequestDetail.tenantAddr.addrLine1,
         mailing_address_line_2: printRequestDetail.tenantAddr.addrLine2,
         mailing_address_line_3: printRequestDetail.tenantAddr.addrLine3,
@@ -130,22 +131,28 @@ export class TTLSService {
   }
 
   // returns the individual name and if there is none, then it returns the legal name
-  getPrimaryContactName(ttlsJSON: {
-    first_name: string;
-    middle_name: string;
-    last_name: string;
-    legal_name: string;
+  getPrimaryContactName(prdObject: {
+    tenantAddr: {
+      first_name: string;
+      middle_name: string;
+      last_name: string;
+      legal_name: string;
+    };
   }) {
-    if (ttlsJSON.first_name || ttlsJSON.middle_name || ttlsJSON.last_name) {
+    if (
+      prdObject.tenantAddr.first_name ||
+      prdObject.tenantAddr.middle_name ||
+      prdObject.tenantAddr.last_name
+    ) {
       return (
-        ttlsJSON.first_name +
+        prdObject.tenantAddr.first_name +
         " " +
-        ttlsJSON.middle_name +
+        prdObject.tenantAddr.middle_name +
         " " +
-        ttlsJSON.last_name
+        prdObject.tenantAddr.last_name
       );
-    } else if (ttlsJSON.legal_name) {
-      return ttlsJSON.legal_name;
+    } else if (prdObject.tenantAddr.legal_name) {
+      return prdObject.tenantAddr.legal_name;
     }
     return "";
   }

--- a/frontend/src/ttls/ttls.service.ts
+++ b/frontend/src/ttls/ttls.service.ts
@@ -133,26 +133,26 @@ export class TTLSService {
   // returns the individual name and if there is none, then it returns the legal name
   getPrimaryContactName(prdObject: {
     tenantAddr: {
-      first_name: string;
-      middle_name: string;
-      last_name: string;
-      legal_name: string;
+      firstName: string;
+      middleName: string;
+      lastName: string;
+      legalName: string;
     };
   }) {
     if (
-      prdObject.tenantAddr.first_name ||
-      prdObject.tenantAddr.middle_name ||
-      prdObject.tenantAddr.last_name
+      prdObject.tenantAddr.firstName ||
+      prdObject.tenantAddr.middleName ||
+      prdObject.tenantAddr.lastName
     ) {
       return (
-        prdObject.tenantAddr.first_name +
+        prdObject.tenantAddr.firstName +
         " " +
-        prdObject.tenantAddr.middle_name +
+        prdObject.tenantAddr.middleName +
         " " +
-        prdObject.tenantAddr.last_name
+        prdObject.tenantAddr.lastName
       );
-    } else if (prdObject.tenantAddr.legal_name) {
-      return prdObject.tenantAddr.legal_name;
+    } else if (prdObject.tenantAddr.legalName) {
+      return prdObject.tenantAddr.legalName;
     }
     return "";
   }


### PR DESCRIPTION
- Set the licence holder name to legal name if no first/middle/last name exist (this was happening on the frontend already but not in the database)
- Fix an issue with displaying the area section.
- Move mailing address + licence holder name parsing to ttlsService