### PR TITLE
disable docgen guard

### DIFF
--- a/frontend/src/authentication/generate-report.guard.ts
+++ b/frontend/src/authentication/generate-report.guard.ts
@@ -18,12 +18,13 @@ export class GenerateReportGuard implements CanActivate {
       request.session.data.activeAccount &&
       request.session.data.activeAccount.client_roles
     ) {
-      for (let entry of request.session.data.activeAccount.client_roles) {
-        if (entry == "generate_documents") {
-          return true;
-        }
-      }
-      throw new ForbiddenException("Document generation privileges not found.");
+      // for (let entry of request.session.data.activeAccount.client_roles) {
+      //   if (entry == "generate_documents") {
+      //     return true;
+      //   }
+      // }
+      // throw new ForbiddenException("Document generation privileges not found.");
+      return true;
     }
   }
 }


### PR DESCRIPTION
For now, return true in the guard instead of checking for the proper role.