### PR TITLE
treat tfn as string, update contact name

### DIFF
--- a/frontend/src/report/report.controller.ts
+++ b/frontend/src/report/report.controller.ts
@@ -42,7 +42,7 @@ export class ReportController {
   getReportName(
     @Param("tfn") tenureFileNumber: string
   ): Promise<{ reportName: string }> {
-    return this.ttlsService.generateReportName(+tenureFileNumber);
+    return this.ttlsService.generateReportName(tenureFileNumber);
   }
 
   @Post("generateReport")

--- a/frontend/src/ttls/ttls.service.ts
+++ b/frontend/src/ttls/ttls.service.ts
@@ -159,12 +159,19 @@ export class TTLSService {
     return "";
   }
 
-  // returns the individual name and if there is none, then it returns the legal name
-  getContactAgent(tenantAddr: { firstName: string; middleName: string }) {
-    if (tenantAddr.firstName || tenantAddr.middleName) {
+  // returns the individual name
+  getContactAgent(tenantAddr: {
+    firstName: string;
+    middleName: string;
+    lastName: string;
+  }) {
+    if (tenantAddr.firstName || tenantAddr.middleName || tenantAddr.lastName) {
       let name = tenantAddr.firstName ? tenantAddr.firstName : "";
       name = tenantAddr.middleName
         ? name.concat(" " + tenantAddr.middleName)
+        : name;
+      name = tenantAddr.lastName
+        ? name.concat(" " + tenantAddr.lastName)
         : name;
       return name;
     }
@@ -284,7 +291,7 @@ export class TTLSService {
       });
   }
 
-  async generateReportName(tenureFileNumber: number) {
+  async generateReportName(tenureFileNumber: string) {
     const url =
       `${hostname}:${port}/print-request-log/version/` + tenureFileNumber;
     // grab the next version string for the dtid


### PR DESCRIPTION
Tenure File Number was sometimes being treated as a number causing it to lose leading 0's, treat it as a string in all cases now.

The Contact Agent variable was set to just use the first name and middle name of the contact, added the last name as well.