### PR TITLE
allow client_roles to be null and still generate report

### DIFF
--- a/frontend/src/authentication/generate-report.guard.ts
+++ b/frontend/src/authentication/generate-report.guard.ts
@@ -13,18 +13,17 @@ export class GenerateReportGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request: Request & { session? } = context.switchToHttp().getRequest();
 
-    if (
-      request.session.data &&
-      request.session.data.activeAccount &&
-      request.session.data.activeAccount.client_roles
-    ) {
+    if (request.session.data && request.session.data.activeAccount) {
+      // if (request.session.data.activeAccount.client_roles) {
       // for (let entry of request.session.data.activeAccount.client_roles) {
       //   if (entry == "generate_documents") {
       //     return true;
       //   }
       // }
       // throw new ForbiddenException("Document generation privileges not found.");
+      // } else {
       return true;
+      // }
     }
   }
 }


### PR DESCRIPTION
The GenerateReportGuard was checking that client_roles was not null before allowing the report to be generated.