### PR TITLE
updating the manage-templates page

### DIFF
--- a/backend/src/nfr_data/nfr_data.service.ts
+++ b/backend/src/nfr_data/nfr_data.service.ts
@@ -95,7 +95,9 @@ export class NFRDataService {
         return nfrDataVariable;
       }
     );
-    await this.deleteDataVarsAndProvs(nfrData, provisionArray, variableArray);
+    if (nfrData) {
+      await this.deleteDataVarsAndProvs(nfrData, provisionArray, variableArray);
+    }
 
     await this.nfrDataProvisionRepository.save(nfrDataProvisions);
     await this.nfrDataVariableRepository.save(nfrDataVariables);
@@ -185,9 +187,11 @@ export class NFRDataService {
     variableArray: { variable_id: number; variable_value: string }[]
   ) {
     // Delete data provisions that have been removed by the user
-    const oldProvisionIds = nfrData.nfr_data_provisions.map(
-      (dataProvision) => dataProvision.nfr_provision.id
-    );
+    const oldProvisionIds = nfrData
+      ? nfrData.nfr_data_provisions.map(
+          (dataProvision) => dataProvision.nfr_provision.id
+        )
+      : [];
     const newProvisionIds = provisionArray.map(
       ({ provision_id }) => provision_id
     );
@@ -204,9 +208,11 @@ export class NFRDataService {
     }
 
     // Delete data variables that have been removed by the user
-    const oldVariableIds = nfrData.nfr_data_variables.map(
-      (dataVariable) => dataVariable.nfr_variable.id
-    );
+    const oldVariableIds = nfrData
+      ? nfrData.nfr_data_variables.map(
+          (dataVariable) => dataVariable.nfr_variable.id
+        )
+      : [];
     const newVariableIds = variableArray.map(({ variable_id }) => variable_id);
     const variablesToDelete = oldVariableIds.filter(
       (item) => !newVariableIds.includes(item)
@@ -277,14 +283,18 @@ export class NFRDataService {
           },
         },
       });
-      const existingDataProvisions = nfrData.nfr_data_provisions;
-      const provisionIds = existingDataProvisions.map(
-        (dataProvision) => dataProvision.nfr_provision.id
-      );
-      const existingDataVariables = nfrData.nfr_data_variables;
-      const variableIds = existingDataVariables.map(
-        (dataVariable) => dataVariable.nfr_variable.id
-      );
+      const provisionIds =
+        nfrData && nfrData.nfr_data_provisions
+          ? nfrData.nfr_data_provisions.map(
+              (dataProvision) => dataProvision.nfr_provision.id
+            )
+          : [];
+      const variableIds =
+        nfrData && nfrData.nfr_data_variables
+          ? nfrData.nfr_data_variables.map(
+              (dataVariable) => dataVariable.nfr_variable.id
+            )
+          : [];
       return { nfrData, provisionIds, variableIds };
     } catch (err) {
       console.log(err);

--- a/backend/src/nfr_provision/dto/create-nfr_provision.dto.ts
+++ b/backend/src/nfr_provision/dto/create-nfr_provision.dto.ts
@@ -9,6 +9,8 @@ export class CreateNFRProvisionDto extends PickType(NFRProvisionDto, [
   "max",
   "provision_name",
   "free_text",
+  "help_text",
   "category",
+  "variants",
   "create_userid",
 ] as const) {}

--- a/backend/src/nfr_provision/dto/nfr_provision.dto.ts
+++ b/backend/src/nfr_provision/dto/nfr_provision.dto.ts
@@ -6,7 +6,9 @@ export class NFRProvisionDto {
   max?: number;
   provision_name?: string;
   free_text?: string;
+  help_text?: string;
   category?: string;
+  variants?: number[];
   create_userid?: string;
   update_userid?: string;
 }

--- a/backend/src/nfr_provision/dto/update-nfr_provision.dto.ts
+++ b/backend/src/nfr_provision/dto/update-nfr_provision.dto.ts
@@ -9,6 +9,8 @@ export class UpdateNFRProvisionDto extends PickType(NFRProvisionDto, [
   "max",
   "provision_name",
   "free_text",
+  "help_text",
   "category",
+  "variants",
   "update_userid",
 ] as const) {}

--- a/backend/src/nfr_provision/entities/nfr_provision.entity.ts
+++ b/backend/src/nfr_provision/entities/nfr_provision.entity.ts
@@ -54,7 +54,10 @@ export class NFRProvision {
     }
   )
   provision_variables: NFRProvisionVariable[];
-  @ManyToMany(() => NFRProvisionVariant, { nullable: true, cascade: true })
+  @ManyToMany(() => NFRProvisionVariant, {
+    nullable: true,
+    eager: true,
+  })
   @JoinTable()
   provision_variant: NFRProvisionVariant[];
   @OneToMany(

--- a/backend/src/nfr_provision/nfr_provision.controller.ts
+++ b/backend/src/nfr_provision/nfr_provision.controller.ts
@@ -66,6 +66,11 @@ export class NFRProvisionController {
     return this.nfrProvisionService.getVariablesByVariant(variantName);
   }
 
+  @Get("get-all-mandatory-provisions/:id")
+  getMandatoryProvisions() {
+    return this.nfrProvisionService.getMandatoryProvisions();
+  }
+
   @Get("get-mandatory-provisions/variant/:variant")
   getMandatoryProvisionsByVariant(@Param("variant") variantName: string) {
     return this.nfrProvisionService.getMandatoryProvisionsByVariant(

--- a/backend/src/nfr_provision/nfr_provision.controller.ts
+++ b/backend/src/nfr_provision/nfr_provision.controller.ts
@@ -73,6 +73,11 @@ export class NFRProvisionController {
     );
   }
 
+  @Get("get-variants-with-ids/:id")
+  getVariantsWithIds() {
+    return this.nfrProvisionService.getVariantsWithIds();
+  }
+
   @Delete(":id")
   remove(@Param("id") id: number) {
     return this.nfrProvisionService.remove(id);

--- a/backend/src/nfr_provision/nfr_provision.service.ts
+++ b/backend/src/nfr_provision/nfr_provision.service.ts
@@ -232,6 +232,12 @@ export class NFRProvisionService {
     });
     return provisionVariables;
   }
+  async getMandatoryProvisions(): Promise<number[]> {
+    const provisions = await this.nfrProvisionRepository.find({
+      where: { mandatory: true },
+    });
+    return provisions.map((provision) => provision.id);
+  }
 
   async getMandatoryProvisionsByVariant(
     variantName: string

--- a/frontend/public/css/custom.css
+++ b/frontend/public/css/custom.css
@@ -191,6 +191,10 @@ td input[type="checkbox"] {
   background-color: lightgreen;
 }
 
+#group-select option.defaultSelect {
+  background-color: white;
+}
+
 .variant-name {
   display: inline-block;
   width: 80%;

--- a/frontend/public/css/custom.css
+++ b/frontend/public/css/custom.css
@@ -190,3 +190,11 @@ td input[type="checkbox"] {
 #group-select option.viewed {
   background-color: lightgreen;
 }
+
+.variant-name {
+  display: inline-block;
+  width: 80%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/frontend/public/js/manage-templates.js
+++ b/frontend/public/js/manage-templates.js
@@ -118,10 +118,11 @@ $(document).ready(function () {
         { data: "edit" },
         { data: "id" },
         { data: "variants" },
+        { data: "mandatory" },
       ],
       columnDefs: [
         {
-          targets: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+          targets: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
           render: function (data, type, row, meta) {
             if (type === "display") {
               var columnTypes = [
@@ -136,13 +137,14 @@ $(document).ready(function () {
                 "edit",
                 "id",
                 "variants",
+                "mandatory",
               ];
               var columnType = columnTypes[meta.col];
               var id = row["id"];
               var group = row["provision_group"];
               var max = row["max"];
+              var mandatory = row["mandatory"];
               var variants = JSON.stringify(row["variants"]);
-              const mandatoryProvision = mandatoryProvisionIds.includes(id);
 
               if (columnType === "active_flag") {
                 const checked = data === true ? "checked" : "";
@@ -150,7 +152,8 @@ $(document).ready(function () {
               } else if (
                 columnType === "help_text" ||
                 columnType === "id" ||
-                columnType === "variants"
+                columnType === "variants" ||
+                columnType === "mandatory"
               ) {
                 return `<input type='hidden' id='${columnType}-${id}' value='${data}' />`;
               } else if (columnType === "edit") {
@@ -462,7 +465,6 @@ function confirmAddProvision() {
     }
   });
   const mandatory = $("#addProvisionMandatory").is(":checked");
-  console.log(mandatory);
   const data = JSON.stringify({
     type: type,
     provision_group: provision_group,
@@ -550,6 +552,8 @@ function openEditModal() {
   const help_text = $(`#help_text-${provisionId}`).val();
   const category = $(`#category-${provisionId}`).val();
   const variants = $(this).data("variants");
+  const mandatory = $(this).data("mandatory");
+
   let provision_group_text = "";
   const matchingRow = $("#groupMaxTable")
     .find("tr td:first-child")
@@ -586,6 +590,7 @@ function openEditModal() {
       checkbox.checked = false;
     }
   });
+  $("#editProvisionMandatory").prop("checked", mandatory);
   $("#editProvisionModal").modal("toggle");
 }
 function editProvision() {
@@ -606,7 +611,6 @@ function editProvision() {
     }
   });
   const mandatory = $("#editProvisionMandatory").is(":checked");
-  console.log("mandatory: " + mandatory);
   const data = JSON.stringify({
     id: id,
     type: type,

--- a/frontend/public/js/manage-templates.js
+++ b/frontend/public/js/manage-templates.js
@@ -112,14 +112,16 @@ $(document).ready(function () {
         { data: "max" },
         { data: "provision_name" },
         { data: "free_text" },
+        { data: "help_text" },
         { data: "category" },
         { data: "active_flag" },
         { data: "edit" },
         { data: "id" },
+        { data: "variants" },
       ],
       columnDefs: [
         {
-          targets: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+          targets: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
           render: function (data, type, row, meta) {
             if (type === "display") {
               var columnTypes = [
@@ -128,23 +130,30 @@ $(document).ready(function () {
                 "max",
                 "provision_name",
                 "free_text",
+                "help_text",
                 "category",
                 "active_flag",
                 "edit",
                 "id",
+                "variants",
               ];
               var columnType = columnTypes[meta.col];
               var id = row["id"];
               var group = row["provision_group"];
               var max = row["max"];
+              var variants = JSON.stringify(row["variants"]);
 
               if (columnType === "active_flag") {
                 const checked = data === true ? "checked" : "";
                 return `<input type='checkbox' id='active-${id}' data-id='${id}' data-group='${group}' data-max='${max}' name='radioActive' ${checked}>`;
-              } else if (columnType === "id") {
+              } else if (
+                columnType === "help_text" ||
+                columnType === "id" ||
+                columnType === "variants"
+              ) {
                 return `<input type='hidden' id='${columnType}-${id}' value='${data}' />`;
               } else if (columnType === "edit") {
-                return `<a href="#" data-id="${id}" onclick="openEditModal.call(this)">Edit</a>`;
+                return `<a href="#" data-id="${id}" data-variants="${variants}" onclick="openEditModal.call(this)">Edit</a>`;
               } else {
                 return `<input type='text' id='${columnType}-${id}' value='${data}' readonly style='color: gray; width: 100%;' />`;
               }
@@ -154,12 +163,12 @@ $(document).ready(function () {
           },
         },
         {
-          targets: [6],
+          targets: [7],
           className: "text-center",
           orderDataType: "dom-checkbox",
         },
         {
-          targets: [7, 8],
+          targets: [8, 9, 10],
           orderable: false,
         },
       ],
@@ -354,7 +363,15 @@ function addProvision() {
   const provision_group_text = $("#addProvisionGroupText").val();
   const provision_name = $("#addProvisionName").val();
   const free_text = $("#addProvisionFreeText").val();
+  const help_text = $("#addProvisionHelpText").val();
   const category = $("#addProvisionCategory").val();
+  const variantCheckboxes = document.querySelectorAll(".addProvisionVariant");
+  const variants = [];
+  variantCheckboxes.forEach((checkbox) => {
+    if (checkbox.checked) {
+      variants.push(checkbox.dataset.id);
+    }
+  });
   const data = JSON.stringify({
     type: type,
     provision_group: provision_group,
@@ -362,7 +379,9 @@ function addProvision() {
     provision_name: provision_name,
     provision_group_text: provision_group_text,
     free_text: free_text,
+    help_text: help_text,
     category: category,
+    variants: variants,
   });
   const matchingRow = $("#groupMaxTable")
     .find("tr td:first-child")
@@ -428,7 +447,15 @@ function confirmAddProvision() {
   const max = $("#addProvisionMax").val();
   const provision_name = $("#addProvisionName").val();
   const free_text = $("#addProvisionFreeText").val();
+  const help_text = $("#addProvisionHelpText").val();
   const category = $("#addProvisionCategory").val();
+  const variantCheckboxes = document.querySelectorAll(".addProvisionVariant");
+  const variants = [];
+  variantCheckboxes.forEach((checkbox) => {
+    if (checkbox.checked) {
+      variants.push(checkbox.dataset.id);
+    }
+  });
   const data = JSON.stringify({
     type: type,
     provision_group: provision_group,
@@ -436,7 +463,9 @@ function confirmAddProvision() {
     max: max,
     provision_name: provision_name,
     free_text: free_text,
+    help_text: help_text,
     category: category,
+    category: variants,
   });
   fetch("admin/add-provision", {
     method: "POST",
@@ -510,7 +539,9 @@ function openEditModal() {
   const max = $(`#max-${provisionId}`).val();
   const provision_name = $(`#provision_name-${provisionId}`).val();
   const free_text = $(`#free_text-${provisionId}`).val();
+  const help_text = $(`#help_text-${provisionId}`).val();
   const category = $(`#category-${provisionId}`).val();
+  const variants = $(this).data("variants");
   let provision_group_text = "";
   const matchingRow = $("#groupMaxTable")
     .find("tr td:first-child")
@@ -536,7 +567,17 @@ function openEditModal() {
   $("#editProvisionMax").val(max);
   $("#editProvisionName").val(provision_name);
   $("#editProvisionFreeText").val(free_text);
+  $("#editProvisionHelpText").val(help_text);
   $("#editProvisionCategory").val(category);
+  const variantCheckboxes = document.querySelectorAll(".editProvisionVariant");
+  variantCheckboxes.forEach((checkbox) => {
+    const variantId = parseInt(checkbox.dataset.id);
+    if (variants.includes(variantId)) {
+      checkbox.checked = true;
+    } else {
+      checkbox.checked = false;
+    }
+  });
   $("#editProvisionModal").modal("toggle");
 }
 function editProvision() {
@@ -547,7 +588,15 @@ function editProvision() {
   const max = $("#editProvisionMax").val();
   const provision_name = $("#editProvisionName").val();
   const free_text = $("#editProvisionFreeText").val();
+  const help_text = $("#editProvisionHelpText").val();
   const category = $("#editProvisionCategory").val();
+  const variantCheckboxes = document.querySelectorAll(".editProvisionVariant");
+  const variants = [];
+  variantCheckboxes.forEach((checkbox) => {
+    if (checkbox.checked) {
+      variants.push(checkbox.dataset.id);
+    }
+  });
   const data = JSON.stringify({
     id: id,
     type: type,
@@ -556,7 +605,9 @@ function editProvision() {
     max: max,
     provision_name: provision_name,
     free_text: free_text,
+    help_text: help_text,
     category: category,
+    variants: variants,
   });
   const matchingRow = $("#groupMaxTable")
     .find("tr td:first-child")
@@ -623,7 +674,15 @@ function confirmEditProvision() {
   const max = $("#editProvisionMax").val();
   const provision_name = $("#editProvisionName").val();
   const free_text = $("#editProvisionFreeText").val();
+  const help_text = $("#editProvisionHelpText").val();
   const category = $("#editProvisionCategory").val();
+  const variantCheckboxes = document.querySelectorAll(".editProvisionVariant");
+  const variants = [];
+  variantCheckboxes.forEach((checkbox) => {
+    if (checkbox.checked) {
+      variants.push(checkbox.dataset.id);
+    }
+  });
   const data = JSON.stringify({
     id: id,
     type: type,
@@ -632,7 +691,9 @@ function confirmEditProvision() {
     max: max,
     provision_name: provision_name,
     free_text: free_text,
+    help_text: help_text,
     category: category,
+    variants: variants,
   });
   fetch("admin/update-provision", {
     method: "POST",

--- a/frontend/public/js/manage-templates.js
+++ b/frontend/public/js/manage-templates.js
@@ -142,6 +142,7 @@ $(document).ready(function () {
               var group = row["provision_group"];
               var max = row["max"];
               var variants = JSON.stringify(row["variants"]);
+              const mandatoryProvision = mandatoryProvisionIds.includes(id);
 
               if (columnType === "active_flag") {
                 const checked = data === true ? "checked" : "";
@@ -153,7 +154,7 @@ $(document).ready(function () {
               ) {
                 return `<input type='hidden' id='${columnType}-${id}' value='${data}' />`;
               } else if (columnType === "edit") {
-                return `<a href="#" data-id="${id}" data-variants="${variants}" onclick="openEditModal.call(this)">Edit</a>`;
+                return `<a href="#" data-id="${id}" data-variants="${variants}" data-mandatory="${mandatory}" onclick="openEditModal.call(this)">Edit</a>`;
               } else {
                 return `<input type='text' id='${columnType}-${id}' value='${data}' readonly style='color: gray; width: 100%;' />`;
               }
@@ -174,7 +175,9 @@ $(document).ready(function () {
       ],
       drawCallback: function (settings) {
         // add event listeners to the provision checkboxes
-        const checkboxes = document.querySelectorAll('input[type="checkbox"]');
+        const checkboxes = document.querySelectorAll(
+          'input[name="radioActive"]'
+        );
         if (checkboxes.length > 0) {
           checkboxes.forEach((checkbox) => {
             checkbox.addEventListener("click", function () {
@@ -372,6 +375,7 @@ function addProvision() {
       variants.push(checkbox.dataset.id);
     }
   });
+  const mandatory = $("#addProvisionMandatory").is(":checked");
   const data = JSON.stringify({
     type: type,
     provision_group: provision_group,
@@ -382,6 +386,7 @@ function addProvision() {
     help_text: help_text,
     category: category,
     variants: variants,
+    mandatory: mandatory,
   });
   const matchingRow = $("#groupMaxTable")
     .find("tr td:first-child")
@@ -456,6 +461,8 @@ function confirmAddProvision() {
       variants.push(checkbox.dataset.id);
     }
   });
+  const mandatory = $("#addProvisionMandatory").is(":checked");
+  console.log(mandatory);
   const data = JSON.stringify({
     type: type,
     provision_group: provision_group,
@@ -465,7 +472,8 @@ function confirmAddProvision() {
     free_text: free_text,
     help_text: help_text,
     category: category,
-    category: variants,
+    variants: variants,
+    mandatory: mandatory,
   });
   fetch("admin/add-provision", {
     method: "POST",
@@ -597,6 +605,8 @@ function editProvision() {
       variants.push(checkbox.dataset.id);
     }
   });
+  const mandatory = $("#editProvisionMandatory").is(":checked");
+  console.log("mandatory: " + mandatory);
   const data = JSON.stringify({
     id: id,
     type: type,
@@ -608,6 +618,7 @@ function editProvision() {
     help_text: help_text,
     category: category,
     variants: variants,
+    mandatory: mandatory,
   });
   const matchingRow = $("#groupMaxTable")
     .find("tr td:first-child")
@@ -683,6 +694,7 @@ function confirmEditProvision() {
       variants.push(checkbox.dataset.id);
     }
   });
+  const mandatory = $("#editProvisionMandatory").is(":checked");
   const data = JSON.stringify({
     id: id,
     type: type,
@@ -694,6 +706,7 @@ function confirmEditProvision() {
     help_text: help_text,
     category: category,
     variants: variants,
+    mandatory: mandatory,
   });
   fetch("admin/update-provision", {
     method: "POST",

--- a/frontend/public/js/nfr.js
+++ b/frontend/public/js/nfr.js
@@ -14,8 +14,6 @@ if (Array.isArray(groupMaxJsonArray) && groupMaxJsonArray.length > 0) {
 }
 let groupMaxTable;
 let provisionTable, variableTable, selectedProvisionsTable;
-// color css for provision group dropdown
-$("#group-select").find("option:first-child").addClass("viewed");
 
 const nfrDataId = $("#nfrDataId").val();
 $(".dataSection dd").each(function () {
@@ -91,10 +89,11 @@ provisionTable = $("#provisionTable").DataTable({
           if (columnType === "select") {
             const checked =
               enabledProvisions.includes(id) === true ? "checked" : "";
-            const mandatory =
-              checked == "checked" && mandatoryProvisions.includes(id) === true
-                ? "disabled"
-                : "";
+            // const mandatory =
+            //   checked == "checked" && mandatoryProvisions.includes(id) === true
+            //     ? "disabled"
+            //     : "";
+            const mandatory = "";
             return `<input type='checkbox' class='provisionSelect' id='active-${id}' data-id='${id}' data-group='${group}' data-max='${max}' ${checked} ${mandatory}>`;
           } else if (
             columnType === "max" ||
@@ -378,7 +377,8 @@ $("#documentVariantId").on("change", function () {
     .then((res) => res.json())
     .then((resJson) => {
       mandatoryProvisions = resJson;
-      enabledProvisions = mandatoryProvisions;
+      // enabledProvisions = mandatoryProvisions;
+      enabledProvisions = [];
       provisionTable.ajax.url(pUrl).load();
     });
 });
@@ -386,27 +386,37 @@ $("#documentVariantId").on("change", function () {
 // event listener for the Select A Group dropdown
 $("#group-select").on("change", function () {
   const selectedGroup = $(this).val();
-  const selectedOption = $(this).find("option:selected");
-  selectedOption.addClass("viewed");
-  provisionTable.rows().every(function () {
-    const provisionGroup = this.data().provision_group;
-    if (selectedGroup == "" || provisionGroup == selectedGroup) {
-      $(this.node()).show();
-    } else {
-      $(this.node()).hide();
+  if (selectedGroup != 0) {
+    const selectedOption = $(this).find("option:selected");
+    selectedOption.addClass("viewed");
+    provisionTable.rows().every(function () {
+      const provisionGroup = this.data().provision_group;
+      if (selectedGroup == "" || provisionGroup == selectedGroup) {
+        $(this.node()).show();
+      } else {
+        $(this.node()).hide();
+      }
+    });
+    if (Array.isArray(groupMaxJsonArray) && groupMaxJsonArray.length > 0) {
+      const groupMax = groupMaxJsonArray.find(
+        (element) => element.provision_group == selectedGroup
+      ).max;
+      $("#maxGroupNum").text(groupMax);
     }
-  });
-  if (Array.isArray(groupMaxJsonArray) && groupMaxJsonArray.length > 0) {
-    const groupMax = groupMaxJsonArray.find(
-      (element) => element.provision_group == selectedGroup
-    ).max;
-    $("#maxGroupNum").text(groupMax);
+  } else {
+    provisionTable.rows().every(function () {
+      $(this.node()).hide();
+    });
   }
 });
 
 function filterRows() {
   const selectedGroup = $("#group-select").val();
-  if (Array.isArray(groupMaxJsonArray) && groupMaxJsonArray.length > 0) {
+  if (
+    selectedGroup != 0 &&
+    Array.isArray(groupMaxJsonArray) &&
+    groupMaxJsonArray.length > 0
+  ) {
     const groupMax = groupMaxJsonArray.find(
       (element) => element.provision_group == selectedGroup
     ).max;
@@ -418,6 +428,10 @@ function filterRows() {
       } else {
         $(this.node()).hide();
       }
+    });
+  } else {
+    provisionTable.rows().every(function () {
+      $(this.node()).hide();
     });
   }
 }

--- a/frontend/src/admin/admin.controller.ts
+++ b/frontend/src/admin/admin.controller.ts
@@ -187,11 +187,6 @@ export class AdminController {
     return this.adminService.getTemplates(reportId);
   }
 
-  @Get("search-nfr-data")
-  getNFRData(): Promise<any> {
-    return this.adminService.getNFRData();
-  }
-
   @Get("open-document/:nfr_id")
   setSessionDocument(
     @Session() session: { data?: SessionData },

--- a/frontend/src/admin/admin.controller.ts
+++ b/frontend/src/admin/admin.controller.ts
@@ -234,8 +234,10 @@ export class AdminController {
       provision_group_text: string;
       max: number;
       provision: string;
-      freeText: string;
+      free_text: string;
+      help_text: string;
       category: string;
+      variants: number[];
     },
     @Session() session: { data?: SessionData }
   ) {
@@ -253,8 +255,10 @@ export class AdminController {
       provision_group_text: string;
       max: number;
       provision: string;
-      freeText: string;
+      free_text: string;
+      help_text: string;
       category: string;
+      variants: number[];
     },
     @Session() session: { data?: SessionData }
   ) {

--- a/frontend/src/admin/admin.service.ts
+++ b/frontend/src/admin/admin.service.ts
@@ -410,8 +410,10 @@ export class AdminService {
       "max",
       "provision_name",
       "free_text",
+      "help_text",
       "category",
       "active_flag",
+      "variants",
     ];
     const url = `${hostname}:${port}/nfr-provision`;
     const nfrProvisions = await axios
@@ -461,8 +463,10 @@ export class AdminService {
       provision_group_text: string;
       max: number;
       provision: string;
-      freeText: string;
+      free_text: string;
+      help_text: string;
       category: string;
+      variants: number[];
     },
     create_userid: string
   ) {
@@ -482,8 +486,10 @@ export class AdminService {
       provision_group_text: string;
       max: number;
       provision: string;
-      freeText: string;
+      free_text: string;
+      help_text: string;
       category: string;
+      variants: number[];
     },
     update_userid: string
   ) {

--- a/frontend/src/admin/admin.service.ts
+++ b/frontend/src/admin/admin.service.ts
@@ -309,65 +309,6 @@ export class AdminService {
     return documents;
   }
 
-  async getNFRData() {
-    const nfrDataUrl = `${hostname}:${port}/nfr-data`;
-    const templateUrl = `${hostname}:${port}/document-template/nfr-template-info`;
-    const nfrData = await axios
-      .get(nfrDataUrl)
-      .then((res) => {
-        return res.data;
-      })
-      .catch((err) => console.log(err.response.data));
-    const templateIds = [];
-    for (let entry of nfrData) {
-      templateIds.push(entry.template_id);
-    }
-    const allTemplates: {
-      id: number;
-      file_name: string;
-      active_flag: boolean;
-      is_deleted: boolean;
-      template_version: number;
-    }[] = await axios
-      .post(templateUrl, templateIds)
-      .then((res) => {
-        return res.data;
-      })
-      .catch((err) => console.log(err.response.data));
-
-    // Combine the corresponding templates with the nfr data.
-    const combinedArray = [];
-
-    let i = 0;
-    let j = 0;
-
-    while (i < allTemplates.length && j < nfrData.length) {
-      const template = allTemplates[i];
-      const nfr = nfrData[j];
-
-      if (template.id === nfr.template_id) {
-        if (!template.is_deleted) {
-          combinedArray.push({
-            dtid: nfr.dtid,
-            version: template.template_version,
-            file_name: template.file_name,
-            updated_date: nfr.update_timestamp.split("T")[0],
-            status: nfr.status,
-            active: template.active_flag,
-            nfr_id: nfr.id,
-            variant_name: nfr.variant_name,
-          });
-        }
-        j++;
-      } else if (template.id < nfr.template_id) {
-        i++;
-      } else {
-        j++;
-      }
-    }
-    return combinedArray;
-  }
-
   async getDocumentTemplates(documentType: string): Promise<any> {
     const returnItems = [
       "id",

--- a/frontend/src/admin/admin.service.ts
+++ b/frontend/src/admin/admin.service.ts
@@ -414,6 +414,7 @@ export class AdminService {
       "category",
       "active_flag",
       "variants",
+      "mandatory",
     ];
     const url = `${hostname}:${port}/nfr-provision`;
     const nfrProvisions = await axios

--- a/frontend/src/app.controller.ts
+++ b/frontend/src/app.controller.ts
@@ -401,7 +401,6 @@ export class AppController {
   @Render("search")
   @UseFilters(AuthenticationFilter)
   @UseGuards(AuthenticationGuard)
-  @UseGuards(AdminGuard)
   async searchPage(@Session() session: { data?: SessionData }) {
     let isAdmin = false;
     if (

--- a/frontend/src/app.controller.ts
+++ b/frontend/src/app.controller.ts
@@ -232,10 +232,10 @@ export class AppController {
           : [];
         const mandatoryProvisionIds =
           await this.reportService.getMandatoryProvisionsByVariant(variantName);
-        const combinedProvisions = provisionIds.concat(mandatoryProvisionIds);
-        const enabledProvisions = combinedProvisions.filter(
-          (item, index) => combinedProvisions.indexOf(item) === index
-        );
+        // const combinedProvisions = provisionIds.concat(mandatoryProvisionIds);
+        // const enabledProvisions = combinedProvisions.filter(
+        //   (item, index) => combinedProvisions.indexOf(item) === index
+        // );
         await this.ttlsService.setWebadeToken();
         const response: any = await firstValueFrom(
           this.ttlsService.callHttp(dtid)
@@ -298,7 +298,8 @@ export class AppController {
           nfrDataId: nfrData ? nfrData.id : -1,
           selectedVariant: selectedVariant,
           mandatoryProvisionList: mandatoryProvisionIds,
-          enabledProvisionList: enabledProvisions,
+          // enabledProvisionList: enabledProvisions,
+          enabledProvisionList: provisionIds,
         };
       } catch (err) {
         console.log(err);

--- a/frontend/src/app.controller.ts
+++ b/frontend/src/app.controller.ts
@@ -383,11 +383,8 @@ export class AppController {
         ? "DEVELOPMENT - " + PAGE_TITLES.MANAGE_TEMPLATES
         : PAGE_TITLES.MANAGE_TEMPLATES;
     let variantJsonArray = [];
-    let mandatoryProvisionIds = [];
     if (reportIndex == 2) {
       variantJsonArray = await this.reportService.getVariantsWithIds();
-      mandatoryProvisionIds = await this.reportService.getMandatoryProvisions();
-      console.log(mandatoryProvisionIds);
     }
     return {
       title: title,
@@ -397,7 +394,6 @@ export class AppController {
       primaryContactName: "",
       displayAdmin: displayAdmin,
       variantJsonArray: variantJsonArray,
-      mandatoryProvisionIds: mandatoryProvisionIds,
     };
   }
 

--- a/frontend/src/app.controller.ts
+++ b/frontend/src/app.controller.ts
@@ -383,8 +383,11 @@ export class AppController {
         ? "DEVELOPMENT - " + PAGE_TITLES.MANAGE_TEMPLATES
         : PAGE_TITLES.MANAGE_TEMPLATES;
     let variantJsonArray = [];
+    let mandatoryProvisionIds = [];
     if (reportIndex == 2) {
       variantJsonArray = await this.reportService.getVariantsWithIds();
+      mandatoryProvisionIds = await this.reportService.getMandatoryProvisions();
+      console.log(mandatoryProvisionIds);
     }
     return {
       title: title,
@@ -394,6 +397,7 @@ export class AppController {
       primaryContactName: "",
       displayAdmin: displayAdmin,
       variantJsonArray: variantJsonArray,
+      mandatoryProvisionIds: mandatoryProvisionIds,
     };
   }
 

--- a/frontend/src/app.controller.ts
+++ b/frontend/src/app.controller.ts
@@ -382,6 +382,10 @@ export class AppController {
       process.env.ticdi_environment == "DEVELOPMENT"
         ? "DEVELOPMENT - " + PAGE_TITLES.MANAGE_TEMPLATES
         : PAGE_TITLES.MANAGE_TEMPLATES;
+    let variantJsonArray = [];
+    if (reportIndex == 2) {
+      variantJsonArray = await this.reportService.getVariantsWithIds();
+    }
     return {
       title: title,
       idirUsername: session.data.activeAccount
@@ -389,6 +393,7 @@ export class AppController {
         : "",
       primaryContactName: "",
       displayAdmin: displayAdmin,
+      variantJsonArray: variantJsonArray,
     };
   }
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -19,6 +19,11 @@ async function bootstrap() {
   hbs.registerHelper("json", function (context) {
     return JSON.stringify(context);
   });
+  // used on the manage-templates page
+  hbs.registerHelper("dots", function (variant_name) {
+    const count = 100 - variant_name.length;
+    return ".".repeat(count);
+  });
 
   let sessionOptions: expressSession.SessionOptions;
   sessionOptions = {

--- a/frontend/src/report/report.controller.ts
+++ b/frontend/src/report/report.controller.ts
@@ -174,4 +174,9 @@ export class ReportController {
   getEnabledProvisionsByVariant(@Param("variantName") variantName: string) {
     return this.reportService.getEnabledProvisionsByVariant(variantName);
   }
+
+  @Get("search-nfr-data")
+  getNFRData() {
+    return this.reportService.getNFRData();
+  }
 }

--- a/frontend/src/report/report.service.ts
+++ b/frontend/src/report/report.service.ts
@@ -388,6 +388,13 @@ export class ReportService {
     }
   }
 
+  async getMandatoryProvisions() {
+    const url = `${hostname}:${port}/nfr-provision/get-all-mandatory-provisions/0`;
+    return await axios.get(url).then((res) => {
+      return res.data;
+    });
+  }
+
   async getMandatoryProvisionsByVariant(variantName: string) {
     const url = `${hostname}:${port}/nfr-provision/get-mandatory-provisions/variant/${variantName}`;
     return await axios.get(url).then((res) => {

--- a/frontend/src/report/report.service.ts
+++ b/frontend/src/report/report.service.ts
@@ -402,18 +402,63 @@ export class ReportService {
     });
   }
 
-  async getNfrData(nfrDataId: number): Promise<any> {
-    const url = `${hostname}:${port}/nfr-data/${nfrDataId}`;
-    const data = await axios
-      .get(url, {
-        headers: {
-          "Content-Type": "application/json",
-        },
-      })
+  async getNFRData() {
+    const nfrDataUrl = `${hostname}:${port}/nfr-data`;
+    const templateUrl = `${hostname}:${port}/document-template/nfr-template-info`;
+    const nfrData = await axios
+      .get(nfrDataUrl)
       .then((res) => {
         return res.data;
-      });
-    return data;
+      })
+      .catch((err) => console.log(err.response.data));
+    const templateIds = [];
+    for (let entry of nfrData) {
+      templateIds.push(entry.template_id);
+    }
+    const allTemplates: {
+      id: number;
+      file_name: string;
+      active_flag: boolean;
+      is_deleted: boolean;
+      template_version: number;
+    }[] = await axios
+      .post(templateUrl, templateIds)
+      .then((res) => {
+        return res.data;
+      })
+      .catch((err) => console.log(err.response.data));
+
+    // Combine the corresponding templates with the nfr data.
+    const combinedArray = [];
+
+    let i = 0;
+    let j = 0;
+
+    while (i < allTemplates.length && j < nfrData.length) {
+      const template = allTemplates[i];
+      const nfr = nfrData[j];
+
+      if (template.id === nfr.template_id) {
+        if (!template.is_deleted) {
+          combinedArray.push({
+            dtid: nfr.dtid,
+            version: template.template_version,
+            file_name: template.file_name,
+            updated_date: nfr.update_timestamp.split("T")[0],
+            status: nfr.status,
+            active: template.active_flag,
+            nfr_id: nfr.id,
+            variant_name: nfr.variant_name,
+          });
+        }
+        j++;
+      } else if (template.id < nfr.template_id) {
+        i++;
+      } else {
+        j++;
+      }
+    }
+    return combinedArray;
   }
 
   async getNfrDataByDtid(dtid: number): Promise<any> {

--- a/frontend/src/report/report.service.ts
+++ b/frontend/src/report/report.service.ts
@@ -462,4 +462,11 @@ export class ReportService {
       return res.data;
     });
   }
+
+  async getVariantsWithIds() {
+    const url = `${hostname}:${port}/nfr-provision/get-variants-with-ids/0`;
+    return axios.get(url).then((res) => {
+      return res.data;
+    });
+  }
 }

--- a/frontend/views/pages/manage-templates.hbs
+++ b/frontend/views/pages/manage-templates.hbs
@@ -211,21 +211,36 @@
                                 <input type="text" class="form-control" id="editProvisionCategory" name="type">
                             </div>
                             <div class="form-group">
-                            <label class="mb-2">Variants</label>
-                            {{#each variantJsonArray}}
-                                <div class="row mb-2 pl-2">
-                                <div class="col-sm-8">
-                                    <label class="form-check-label" for="editProvisionVariant-{{this.id}}" style="width:100%">
-                                    <span class="variant-name" style="width:100%">{{this.variant_name}} {{{dots this.variant_name }}}</span>
-                                    </label>
-                                </div>
-                                <div class="col-sm-4">
-                                    <div class="form-check">
-                                    <input type="checkbox" class="form-check-input editProvisionVariant" id="editProvisionVariant-{{this.id}}" data-id="{{this.id}}" name="variant-{{this.id}}">
+                                <label class="mb-2">Variants</label>
+                                {{#each variantJsonArray}}
+                                    <div class="row mb-2 pl-2">
+                                    <div class="col-sm-8">
+                                        <label class="form-check-label" for="editProvisionVariant-{{this.id}}" style="width:100%">
+                                        <span class="variant-name" style="width:100%">{{this.variant_name}} {{{dots this.variant_name }}}</span>
+                                        </label>
+                                    </div>
+                                    <div class="col-sm-4">
+                                        <div class="form-check">
+                                        <input type="checkbox" class="form-check-input editProvisionVariant" id="editProvisionVariant-{{this.id}}" data-id="{{this.id}}" name="variant-{{this.id}}">
+                                        </div>
+                                    </div>
+                                    </div>
+                                {{/each}}
+                            </div>
+                            <div class="form-group">
+                                <label class="mb-2">Mandatory</label>
+                                <div class="row mb-2">
+                                    <div class="col-sm-8">
+                                        <label class="form-check-label" for="editProvisionMandatory" style="width:100%">
+                                            <span class="variant-name" style="width:100%">Is this provision mandatory? {{{ dots "Is this provision mandatory?" }}}</span>
+                                        </label>
+                                    </div>
+                                    <div class="col-sm-4">
+                                        <div class="form-check">
+                                            <input type="checkbox" class="form-check-input" id="editProvisionMandatory">
+                                        </div>
                                     </div>
                                 </div>
-                                </div>
-                            {{/each}}
                             </div>
                             </form>
                         </div>
@@ -295,21 +310,36 @@
                                 <input type="text" class="form-control" id="addProvisionCategory" name="type">
                             </div>
                             <div class="form-group">
-                            <label class="mb-2">Variants</label>
-                            {{#each variantJsonArray}}
-                                <div class="row mb-2 pl-2">
-                                <div class="col-sm-8">
-                                    <label class="form-check-label" for="addProvisionVariant-{{this.id}}" style="width:100%">
-                                    <span class="variant-name" style="width:100%">{{this.variant_name}} {{{dots this.variant_name }}}</span>
-                                    </label>
-                                </div>
-                                <div class="col-sm-4">
-                                    <div class="form-check">
-                                    <input type="checkbox" class="form-check-input addProvisionVariant" id="addProvisionVariant-{{this.id}}" data-id="{{this.id}}" name="variant-{{this.id}}">
+                                <label class="mb-2">Variants</label>
+                                {{#each variantJsonArray}}
+                                    <div class="row mb-2 pl-2">
+                                    <div class="col-sm-8">
+                                        <label class="form-check-label" for="addProvisionVariant-{{this.id}}" style="width:100%">
+                                        <span class="variant-name" style="width:100%">{{this.variant_name}} {{{dots this.variant_name }}}</span>
+                                        </label>
+                                    </div>
+                                    <div class="col-sm-4">
+                                        <div class="form-check">
+                                        <input type="checkbox" class="form-check-input addProvisionVariant" id="addProvisionVariant-{{this.id}}" data-id="{{this.id}}" name="variant-{{this.id}}">
+                                        </div>
+                                    </div>
+                                    </div>
+                                {{/each}}
+                            </div>
+                            <div class="form-group">
+                                <label class="mb-2">Mandatory</label>
+                                <div class="row mb-2">
+                                    <div class="col-sm-8">
+                                        <label class="form-check-label" for="addProvisionMandatory" style="width:100%">
+                                            <span class="variant-name" style="width:100%">Is this provision mandatory? {{{ dots "Is this provision mandatory?" }}}</span>
+                                        </label>
+                                    </div>
+                                    <div class="col-sm-4">
+                                        <div class="form-check">
+                                            <input type="checkbox" class="form-check-input" id="addProvisionMandatory">
+                                        </div>
                                     </div>
                                 </div>
-                                </div>
-                            {{/each}}
                             </div>
                             </form>
                         </div>
@@ -330,7 +360,11 @@
                 </div>
             </div>
         </div>
+        <div id="mandatoryProvisionIds" value=""></div>
     </main>
     <script src="/js/manage-templates.js"></script>
+    <script>
+        const mandatoryProvisionIds = [{{ this.mandatoryProvisionIds }}];
+    </script>
   {{/inline}}
 {{/template}}

--- a/frontend/views/pages/manage-templates.hbs
+++ b/frontend/views/pages/manage-templates.hbs
@@ -51,8 +51,9 @@
                                     <th style="min-width: 200px">Category</th>
                                     <th>Active</th><!-- Active column -->
                                     <th></th><!-- Edit column -->
-                                    <th></th><!-- id column -->
-                                    <th></th><!-- variants column -->
+                                    <th></th><!-- ID column -->
+                                    <th></th><!-- Variants column -->
+                                    <th></th><!-- Mandatory column -->
                                 </thead>
                                 <tbody id="provisionTableBody"></tbody>
                             </table>
@@ -363,8 +364,5 @@
         <div id="mandatoryProvisionIds" value=""></div>
     </main>
     <script src="/js/manage-templates.js"></script>
-    <script>
-        const mandatoryProvisionIds = [{{ this.mandatoryProvisionIds }}];
-    </script>
   {{/inline}}
 {{/template}}

--- a/frontend/views/pages/manage-templates.hbs
+++ b/frontend/views/pages/manage-templates.hbs
@@ -47,10 +47,12 @@
                                     <th>Max</th>
                                     <th style="min-width: 400px">Provision</th>
                                     <th style="min-width: 50px">Free Text</th>
+                                    <th></th> <!-- Help Text -->
                                     <th style="min-width: 200px">Category</th>
                                     <th>Active</th><!-- Active column -->
                                     <th></th><!-- Edit column -->
                                     <th></th><!-- id column -->
+                                    <th></th><!-- variants column -->
                                 </thead>
                                 <tbody id="provisionTableBody"></tbody>
                             </table>
@@ -201,8 +203,29 @@
                                 <input type="text" class="form-control" id="editProvisionFreeText" name="free_text">
                             </div>
                             <div class="form-group">
+                                <label for="editProvisionHelpText">Help Text</label>
+                                <input type="text" class="form-control" id="editProvisionHelpText" name="help_text">
+                            </div>
+                            <div class="form-group">
                                 <label for="editProvisionCategory">Category</label>
                                 <input type="text" class="form-control" id="editProvisionCategory" name="type">
+                            </div>
+                            <div class="form-group">
+                            <label class="mb-2">Variants</label>
+                            {{#each variantJsonArray}}
+                                <div class="row mb-2 pl-2">
+                                <div class="col-sm-8">
+                                    <label class="form-check-label" for="editProvisionVariant-{{this.id}}" style="width:100%">
+                                    <span class="variant-name" style="width:100%">{{this.variant_name}} {{{dots this.variant_name }}}</span>
+                                    </label>
+                                </div>
+                                <div class="col-sm-4">
+                                    <div class="form-check">
+                                    <input type="checkbox" class="form-check-input editProvisionVariant" id="editProvisionVariant-{{this.id}}" data-id="{{this.id}}" name="variant-{{this.id}}">
+                                    </div>
+                                </div>
+                                </div>
+                            {{/each}}
                             </div>
                             </form>
                         </div>
@@ -264,8 +287,29 @@
                                 <input type="text" class="form-control" id="addProvisionFreeText" name="free_text">
                             </div>
                             <div class="form-group">
+                                <label for="addProvisionHelpText">Help Text</label>
+                                <input type="text" class="form-control" id="addProvisionHelpText" name="help_text">
+                            </div>
+                            <div class="form-group">
                                 <label for="addProvisionCategory">Category</label>
                                 <input type="text" class="form-control" id="addProvisionCategory" name="type">
+                            </div>
+                            <div class="form-group">
+                            <label class="mb-2">Variants</label>
+                            {{#each variantJsonArray}}
+                                <div class="row mb-2 pl-2">
+                                <div class="col-sm-8">
+                                    <label class="form-check-label" for="addProvisionVariant-{{this.id}}" style="width:100%">
+                                    <span class="variant-name" style="width:100%">{{this.variant_name}} {{{dots this.variant_name }}}</span>
+                                    </label>
+                                </div>
+                                <div class="col-sm-4">
+                                    <div class="form-check">
+                                    <input type="checkbox" class="form-check-input addProvisionVariant" id="addProvisionVariant-{{this.id}}" data-id="{{this.id}}" name="variant-{{this.id}}">
+                                    </div>
+                                </div>
+                                </div>
+                            {{/each}}
                             </div>
                             </form>
                         </div>

--- a/frontend/views/pages/nfr.hbs
+++ b/frontend/views/pages/nfr.hbs
@@ -117,7 +117,7 @@
                     <legend id="provisionLegend" style="cursor: pointer" class='togvis sectionTitle'><i class="fa fa-plus"></i>  Provisions</legend>
                     <div class="contents" style="display: none;">
                         <span>Select A Group:
-                            <select id="group-select">{{#each groupMaxJsonArray}}<option value="{{this.provision_group}}">{{this.provision_group}} - {{this.provision_group_text}}{{/each}}</option></select>     Max for this Group is <span id="maxGroupNum"></span></span>
+                            <select id="group-select"><option value="0" class="defaultSelect">Select</option>{{#each groupMaxJsonArray}}<option value="{{this.provision_group}}">{{this.provision_group}} - {{this.provision_group_text}}{{/each}}</option></select>     Max for this Group is <span id="maxGroupNum"></span></span>
                         <table id="provisionTable" style="width:100%">
                             <thead>
                                 <th>Type</th>

--- a/frontend/views/pages/search.hbs
+++ b/frontend/views/pages/search.hbs
@@ -45,7 +45,7 @@
                 "paging": false,
                 "bFilter": false,
                 "ajax": {
-                    "url": "admin/search-nfr-data",
+                    "url": "report/search-nfr-data",
                     "dataSrc": ""
                 },
                 "columns": [

--- a/frontend/views/pages/search.hbs
+++ b/frontend/views/pages/search.hbs
@@ -153,7 +153,7 @@
         async function openDocument() {
             const dtid = $('input[name="radioActive"]:checked').data('dtid');
             const variantName = $('input[name="radioActive"]:checked').data('variant_name');
-            window.location.href = `/nfr/dtid/${dtid}/${variantName}`
+            window.location.href = `/dtid/${dtid}/${variantName}`
         }
     </script>
   {{/inline}}


### PR DESCRIPTION
- Updated the add/edit routes for NFR provisions
  - You can now select which variants have access to that provision.
  - Added Help Text field to add/edit provision modal.
  - Added Mandatory Provision option to add/edit provision modal (mandatory provision status does nothing right now).
- Updated NFR page
  - Added Select option to group dropdown
  - Disabled Mandatory provision logic, provisions/variables will no longer be preloaded unless they were previously saved for that DTID.
- Updated Search
  - Made accessible by regular users
  - Fixed the Open button sending users to a 404 page