### PR TITLE
quick fix to provision group select

### DIFF
--- a/frontend/public/js/nfr.js
+++ b/frontend/public/js/nfr.js
@@ -636,7 +636,7 @@ function getVariableJson(provisionIds) {
 function updateGroupSelect(groupMaxJsonArray) {
   // repopulate the group select using the new groupMaxJsonArray
   const selectElement = document.getElementById("group-select");
-  selectElement.innerHTML = "";
+  selectElement.innerHTML = `<option value="0" class="defaultSelect">Select</option>`;
   groupMaxJsonArray.forEach((item) => {
     const optionElement = document.createElement("option");
     optionElement.value = item.provision_group;


### PR DESCRIPTION
The provision group select repopulates after changing the variant type, the Select option wasn't being added in this situation.