### PR TITLE
More changes

### DIFF
--- a/backend/utils/db/init-db.sql
+++ b/backend/utils/db/init-db.sql
@@ -1,17 +1,17 @@
 -- Initialize Database Provisions
 -- Create groups
-INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (1,3,'pgt');
+INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (1,999,'pgt');
+INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (2,999,'pgt');
 INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (5,3,'pgt');
-INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (2,3,'pgt');
 INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (10,3,'pgt');
 INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (12,3,'pgt');
 INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (14,3,'pgt');
-INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (15,3,'pgt');
-INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (20,3,'pgt');
-INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (25,3,'pgt');
+INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (15,1,'pgt');
+INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (20,2,'pgt');
+INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (25,2,'pgt');
 INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (27,3,'pgt');
 INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (28,3,'pgt');
-INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (34,3,'pgt');
+INSERT INTO nfr_provision_group (provision_group, max, provision_group_text) VALUES (34,10,'pgt');
 
 -- Create variants
 INSERT INTO nfr_provision_variant (variant_name) VALUES ('NOTICE OF FINAL REVIEW');

--- a/frontend/public/css/custom.css
+++ b/frontend/public/css/custom.css
@@ -202,3 +202,7 @@ td input[type="checkbox"] {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.input-readonly {
+  color: grey;
+}

--- a/frontend/public/js/nfr.js
+++ b/frontend/public/js/nfr.js
@@ -62,6 +62,7 @@ provisionTable = $("#provisionTable").DataTable({
     { data: "provision_name" },
     { data: "help_text" },
     { data: "category" },
+    { data: "mandatory" },
     { data: "select" },
     { data: "provision_group" },
     { data: "max" },
@@ -70,7 +71,7 @@ provisionTable = $("#provisionTable").DataTable({
   ],
   columnDefs: [
     {
-      targets: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+      targets: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
       render: function (data, type, row, meta) {
         if (type === "display") {
           var columnTypes = [
@@ -78,6 +79,7 @@ provisionTable = $("#provisionTable").DataTable({
             "provision_name",
             "help_text",
             "category",
+            "mandatory",
             "select",
             "provision_group",
             "max",
@@ -88,25 +90,24 @@ provisionTable = $("#provisionTable").DataTable({
           var id = row["id"];
           var group = row["provision_group"];
           var max = row["max"];
+          var mandatory = row["mandatory"] == true ? "Yes" : "No";
 
           if (columnType === "select") {
             const checked =
               enabledProvisions.includes(id) === true ? "checked" : "";
-            // const mandatory =
-            //   checked == "checked" && mandatoryProvisions.includes(id) === true
-            //     ? "disabled"
-            //     : "";
-            const mandatory = "";
-            return `<input type='checkbox' class='provisionSelect' id='active-${id}' data-id='${id}' data-group='${group}' data-max='${max}' ${checked} ${mandatory}>`;
+            return `<input type='checkbox' class='provisionSelect' id='active-${id}' data-id='${id}' data-group='${group}' data-max='${max}' data-mandatory='${mandatory}' ${checked}>`;
           } else if (
             columnType === "max" ||
-            columnType === "provision_group" ||
             columnType === "id" ||
             columnType === "free_text"
           ) {
             return `<input type='hidden' id='${columnType}-${id}' value='${data}' />`;
           } else if (columnType === "help_text") {
             return `<input type='text' value='${data}' title='${data}' tabIndex='-1' readonly style='color: gray; width: 100%;' />`;
+          } else if (columnType === "provision_group") {
+            return `<input type='hidden' class='provisionGroupValue' value='${data}' />`;
+          } else if (columnType === "mandatory") {
+            return `<input type='text' class='isMandatory' value='${mandatory}' tabIndex='-1' readonly style='color: gray; width: 100%;' />`;
           } else {
             return `<input type='text' id='${columnType}-${id}' value='${data}' tabIndex='-1' readonly style='color: gray; width: 100%;' />`;
           }
@@ -116,12 +117,12 @@ provisionTable = $("#provisionTable").DataTable({
       },
     },
     {
-      targets: 4,
+      targets: 5,
       className: "text-center",
       orderDataType: "dom-checkbox",
     },
     {
-      targets: [5, 6, 7, 8],
+      targets: [6, 7, 8, 9],
       orderable: false,
     },
   ],
@@ -528,58 +529,82 @@ function saveForLater() {
 async function generateNFRReport() {
   const tenureFileNumber = $("#tfn").text();
   const dtid = $("#dtid").text();
-  $("#genReport").prop("disabled", true);
-  const reportName = await fetch(
-    `/report/get-nfr-report-name/${dtid}/${tenureFileNumber}`,
-    {
-      method: "GET",
+  const unselectedMandatoryGroups = [];
+  let allMandatorySelected = true;
+  // Check that all mandatory provisions have been selected
+  $("#provisionTable")
+    .find("tbody tr")
+    .each(function () {
+      var isMandatory = $(this).find(".isMandatory").val().trim();
+      var provisionGroup = $(this).find(".provisionGroupValue").val();
+      if (isMandatory === "Yes") {
+        var provisionSelect = $(this).find(".provisionSelect").prop("checked");
+        if (!provisionSelect) {
+          unselectedMandatoryGroups.push(provisionGroup);
+          allMandatorySelected = false;
+        }
+      }
+    });
+  if (allMandatorySelected) {
+    $("#genReport").prop("disabled", true);
+    const reportName = await fetch(
+      `/report/get-nfr-report-name/${dtid}/${tenureFileNumber}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        responseType: "application/json",
+      }
+    )
+      .then((res) => res.json())
+      .then((resJson) => {
+        return resJson.reportName;
+      })
+      .catch(() => {
+        location.reload();
+      });
+
+    const provisionIds = getEnabledProvisionIds();
+    const provisionJson = getProvisionJson(provisionIds);
+    const variableJson = getVariableJson(provisionIds);
+    const data = {
+      dtid: dtid,
+      variantName: variantName,
+      provisionJson: provisionJson,
+      variableJson: variableJson,
+    };
+    fetch(`/report/generate-nfr-report`, {
+      method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
       responseType: "application/json",
-    }
-  )
-    .then((res) => res.json())
-    .then((resJson) => {
-      return resJson.reportName;
+      body: JSON.stringify(data),
     })
-    .catch(() => {
-      location.reload();
-    });
-
-  const provisionIds = getEnabledProvisionIds();
-  const provisionJson = getProvisionJson(provisionIds);
-  const variableJson = getVariableJson(provisionIds);
-  const data = {
-    dtid: dtid,
-    variantName: variantName,
-    provisionJson: provisionJson,
-    variableJson: variableJson,
-  };
-  fetch(`/report/generate-nfr-report`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    responseType: "application/json",
-    body: JSON.stringify(data),
-  })
-    .then((res) => res.blob())
-    .then((blob) => {
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.style.display = "none";
-      a.href = url;
-      a.download = reportName + ".docx";
-      document.body.appendChild(a);
-      a.click();
-      window.URL.revokeObjectURL(url);
-      $("#genReport").prop("disabled", false);
-    })
-    .catch(() => {
-      location.reload();
-      $("#genReport").prop("disabled", false);
-    });
+      .then((res) => res.blob())
+      .then((blob) => {
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.style.display = "none";
+        a.href = url;
+        a.download = reportName + ".docx";
+        document.body.appendChild(a);
+        a.click();
+        window.URL.revokeObjectURL(url);
+        $("#genReport").prop("disabled", false);
+      })
+      .catch(() => {
+        location.reload();
+        $("#genReport").prop("disabled", false);
+      });
+  } else {
+    const uniqueProvisionGroups = [...new Set(unselectedMandatoryGroups)];
+    alert(
+      "There are unselected mandatory provisions the following groups: " +
+        uniqueProvisionGroups.join(", ")
+    );
+  }
 }
 
 function getEnabledProvisionIds() {

--- a/frontend/public/js/nfr.js
+++ b/frontend/public/js/nfr.js
@@ -18,6 +18,9 @@ let provisionTable, variableTable, selectedProvisionsTable;
 const nfrDataId = $("#nfrDataId").val();
 $(".dataSection dd").each(function () {
   if ($(this).text() == "" || $(this).text() == "TBD") {
+    if ($(this).attr("id") == "address2" || $(this).attr("id") == "address3") {
+      $(this).hide();
+    }
     $(this).text(" ");
     $(this).css("border", "solid 1px orange");
   }
@@ -401,9 +404,12 @@ $("#group-select").on("change", function () {
       const groupMax = groupMaxJsonArray.find(
         (element) => element.provision_group == selectedGroup
       ).max;
-      $("#maxGroupNum").text(groupMax);
+      const groupMaxText =
+        groupMax == 999 ? "" : "Max for this Group is " + groupMax;
+      $("#maxGroupNum").text(groupMaxText);
     }
   } else {
+    $("#maxGroupNum").text("");
     provisionTable.rows().every(function () {
       $(this.node()).hide();
     });
@@ -420,7 +426,9 @@ function filterRows() {
     const groupMax = groupMaxJsonArray.find(
       (element) => element.provision_group == selectedGroup
     ).max;
-    $("#maxGroupNum").text(groupMax);
+    const groupMaxText =
+      groupMax == 999 ? "" : "Max for this Group is " + groupMax;
+    $("#maxGroupNum").text(groupMaxText);
     provisionTable.rows().every(function () {
       const provisionGroup = this.data().provision_group;
       if (selectedGroup == "" || provisionGroup == selectedGroup) {
@@ -430,6 +438,7 @@ function filterRows() {
       }
     });
   } else {
+    $("#maxGroupNum").text("");
     provisionTable.rows().every(function () {
       $(this.node()).hide();
     });

--- a/frontend/src/app.controller.ts
+++ b/frontend/src/app.controller.ts
@@ -248,20 +248,19 @@ export class AppController {
           });
         ttlsJSON = await this.ttlsService.formatNFRData(response);
         primaryContactName = ttlsJSON.licenceHolderName;
-        ttlsJSON["interestedParties"] = [
-          {
-            firstName: "First",
-            middleName: "Middle",
-            lastName: "Last",
-            address: "123 fake street",
-          },
-          {
-            firstName: "First2",
-            middleName: "Middle2",
-            lastName: "Last2",
-            address: "346 Miron Drive",
-          },
-        ];
+        const interestedParties = [];
+        if (response.tenantAddr && response.tenantAddr.length > 0) {
+          response.tenantAddr.map((t) => {
+            const interestedParty = {
+              firstName: t.firstName,
+              middleName: t.middleName,
+              lastName: t.lastName,
+              address: this.ttlsService.getMailingAddress(t),
+            }
+            interestedParties.push(interestedParty);
+          })
+        }
+        ttlsJSON["interestedParties"] = interestedParties;
         let selectedVariant = 0;
         switch (variantName) {
           case NFR_VARIANTS.default: {

--- a/frontend/src/report/report.service.ts
+++ b/frontend/src/report/report.service.ts
@@ -307,6 +307,7 @@ export class ReportService {
       "category",
       "provision_group",
       "id",
+      "mandatory",
     ];
     let reduced, provisions;
     if (nfrId != -1) {

--- a/frontend/views/pages/manage-templates.hbs
+++ b/frontend/views/pages/manage-templates.hbs
@@ -196,6 +196,18 @@
                                 <input type="number" class="form-control" id="editProvisionMax" name="max" pattern="[0-9]+">
                             </div>
                             <div class="form-group">
+                                <div class="row mb-2 pl-2">
+                                <div class="col-sm-8">
+                                    <label for="editProvisionMaxUnlimited">No Maximum? {{{dots "No Maximum?" }}}</label>
+                                </div>
+                                <div class="col-sm-4">
+                                    <div class="form-check">
+                                        <input type="checkbox" class="form-check-input" id="editProvisionMaxUnlimited" name="max_unlimited">
+                                    </div>
+                                </div>
+                                </div>
+                            </div>
+                            <div class="form-group">
                                 <label for="editProvisionName">Provision</label>
                                 <input type="text" class="form-control" id="editProvisionName" name="provision">
                             </div>
@@ -293,6 +305,18 @@
                             <div class="form-group">
                                 <label for="addProvisionMax">Max</label>
                                 <input type="number" class="form-control" id="addProvisionMax" name="max" pattern="[0-9]+">
+                            </div>
+                            <div class="form-group">
+                                <div class="row mb-2 pl-2">
+                                <div class="col-sm-8">
+                                    <label for="addProvisionMaxUnlimited">No Maximum? {{{dots "No Maximum?" }}}</label>
+                                </div>
+                                <div class="col-sm-4">
+                                    <div class="form-check">
+                                        <input type="checkbox" class="form-check-input" id="addProvisionMaxUnlimited" name="max_unlimited">
+                                    </div>
+                                </div>
+                                </div>
                             </div>
                             <div class="form-group">
                                 <label for="addProvisionName">Provision</label>

--- a/frontend/views/pages/nfr.hbs
+++ b/frontend/views/pages/nfr.hbs
@@ -117,7 +117,7 @@
                     <legend id="provisionLegend" style="cursor: pointer" class='togvis sectionTitle'><i class="fa fa-plus"></i>  Provisions</legend>
                     <div class="contents" style="display: none;">
                         <span>Select A Group:
-                            <select id="group-select"><option value="0" class="defaultSelect">Select</option>{{#each groupMaxJsonArray}}<option value="{{this.provision_group}}">{{this.provision_group}} - {{this.provision_group_text}}{{/each}}</option></select>     Max for this Group is <span id="maxGroupNum"></span></span>
+                            <select id="group-select"><option value="0" class="defaultSelect">Select</option>{{#each groupMaxJsonArray}}<option value="{{this.provision_group}}">{{this.provision_group}} - {{this.provision_group_text}}{{/each}}</option></select>     <span id="maxGroupNum"></span></span>
                         <table id="provisionTable" style="width:100%">
                             <thead>
                                 <th>Type</th>

--- a/frontend/views/pages/nfr.hbs
+++ b/frontend/views/pages/nfr.hbs
@@ -124,6 +124,7 @@
                                 <th style="min-width: 450px">Provision</th>
                                 <th style="min-width: 200px">Help</th>
                                 <th style="min-width: 150px">Category</th>
+                                <th>Mandatory</th> 
                                 <th></th>
                                 <th style="display: none"></th>
                                 <th style="display: none"></th>
@@ -152,7 +153,7 @@
                         <table id="variableTable" style="width:100%">
                             <thead>
                                 <th style="min-width: 300px">Variable</th>
-                                <th style="min-width: 450px">Value</th>
+                                <th style="min-width: 450px">Enter Text</th>
                                 <th style="min-width: 150px">Help</th>
                                 <th style="display: none"></th>
                                 <th style="display: none"></th>

--- a/frontend/views/pages/nfr.hbs
+++ b/frontend/views/pages/nfr.hbs
@@ -97,15 +97,15 @@
                                 <dt>First Name</dt>
                                 <dd id="firstName">{{ this.firstName }}</dd>
                             </div>
-                            <div class="form-group col-md-2">
+                            <div class="form-group col-md-2 dataSection">
                                 <dt>Middle Name</dt>
                                 <dd id="middleName">{{this.middleName}}</dd>
                             </div>
-                            <div class="form-group col-md-2">
+                            <div class="form-group col-md-2 dataSection">
                                 <dt>Last Name</dt>
                                 <dd id="lastName">{{this.lastName}}</dd>
                             </div>
-                            <div class="form-group col-md-3">
+                            <div class="form-group col-md-3 dataSection">
                                 <dt>Address</dt>
                                 <dd id="address">{{this.address}}</dd>
                             </div>


### PR DESCRIPTION
- Group Select maximum text change
- Address on NFR page display change
- Added Mandatory provision logic & table column, user can no longer generate a document if all mandatory provisions have not been selected.
- Added the option for groups to have no maximum and updated frontend for that change
- Variable 'Value' column header changed to 'Enter Text'
- Interested parties now populates from tenantAddr array, it seems that there will either be a legalname or a first/middle/last but not both so the way interested parties are displayed should probably change. 