### PR TITLE
TICDI-24 nested values

### DIFF
--- a/frontend/src/report/report.service.ts
+++ b/frontend/src/report/report.service.ts
@@ -213,6 +213,7 @@ export class ReportService {
       }
 
       variables[`VAR_${newVariableName}`] = variable_value;
+      variables[`${variable_name}`] = variable_value;
     });
 
     // Format provisions in a way that the document template expects

--- a/frontend/utils/util.ts
+++ b/frontend/utils/util.ts
@@ -91,3 +91,16 @@ export function nfrInterestedParties(
   }
   return result;
 }
+
+// used by report service to convert strings to a specific format
+// such as «DB_TENURE_TYPE» to {d.DB_Tenure_Type}
+export function convertToSpecialCamelCase(str) {
+  return str
+    .toLowerCase()
+    .replace(/_([a-z])/g, function (match, letter) {
+      return "_" + letter.toUpperCase();
+    })
+    .replace(/^[a-z]*/g, function (match, letter) {
+      return match.toUpperCase();
+    });
+}

--- a/frontend/utils/util.ts
+++ b/frontend/utils/util.ts
@@ -95,12 +95,19 @@ export function nfrInterestedParties(
 // used by report service to convert strings to a specific format
 // such as «DB_TENURE_TYPE» to {d.DB_Tenure_Type}
 export function convertToSpecialCamelCase(str) {
-  return str
-    .toLowerCase()
-    .replace(/_([a-z])/g, function (match, letter) {
-      return "_" + letter.toUpperCase();
-    })
-    .replace(/^[a-z]*/g, function (match, letter) {
-      return match.toUpperCase();
-    });
+  if (
+    str.toLowerCase().startsWith("db_") ||
+    str.toLowerCase().startsWith("var_")
+  ) {
+    return str
+      .toLowerCase()
+      .replace(/_([a-z])/g, function (match, letter) {
+        return "_" + letter.toUpperCase();
+      })
+      .replace(/^[a-z]*/g, function (match, letter) {
+        return match.toUpperCase();
+      });
+  } else {
+    return str;
+  }
 }


### PR DESCRIPTION
Added regex to check all provision.free_text and variable values for the character "«" and to update that string to something that the cdogs templating logic will understand.

«DB_TENURE_TYPE» would become {d.DB_Tenure_Type} and «VAR_TELEPHONE_NUMBER» would become {d.VAR_Telephone_Number}

In order to insert values for these nested variables, cdogs gets run a second time.