### PR TITLE
delete all data related to doc type on deletion

### DIFF
--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -10,9 +10,10 @@ import { DocumentTypeModule } from 'src/document_type/document_type.module';
 import { JWTAuthModule } from 'src/auth/jwtauth.module';
 import { JwtAuthGuard } from 'src/auth/jwtauth.guard';
 import { TTLSService } from 'src/ttls/ttls.service';
+import { DocumentDataModule } from 'src/document_data/document_data.module';
 
 @Module({
-  imports: [HttpModule, JWTAuthModule, DocumentTemplateModule, ProvisionModule, DocumentTypeModule],
+  imports: [HttpModule, JWTAuthModule, DocumentTemplateModule, ProvisionModule, DocumentTypeModule, DocumentDataModule],
   providers: [AdminGuard, AdminService, JwtAuthGuard, TTLSService],
   exports: [AdminService],
   controllers: [AdminController],

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -7,6 +7,7 @@ import { DocumentTypeService } from 'src/document_type/document_type.service';
 import { DocumentType } from 'src/document_type/entities/document_type.entity';
 import { TTLSService } from 'src/ttls/ttls.service';
 import { Role } from 'src/enum/role.enum';
+import { DocumentDataService } from 'src/document_data/document_data.service';
 
 const axios = require('axios');
 
@@ -20,7 +21,8 @@ export class AdminService {
     private readonly ttlsService: TTLSService,
     private readonly documentTemplateService: DocumentTemplateService,
     private readonly provisionService: ProvisionService,
-    private readonly documentTypeService: DocumentTypeService
+    private readonly documentTypeService: DocumentTypeService,
+    private readonly documentDataService: DocumentDataService
   ) {
     hostname = process.env.backend_url ? process.env.backend_url : `http://localhost`;
     // local development backend port is 3001, docker backend port is 3000
@@ -443,6 +445,12 @@ export class AdminService {
     try {
       // remove the related doc type provisions
       await this.provisionService.removeDocTypeProvisions(document_type_id);
+      // remove the related doc type provision groups
+      await this.documentTypeService.removeProvisionGroupByDocTypeId(document_type_id);
+      // remove templates related to the doc type
+      await this.documentTemplateService.removeByDocTypeId(document_type_id);
+      // remove the related doc type data
+      await this.documentDataService.removeByDocTypeId(document_type_id);
       // remove the doc type
       await this.documentTypeService.remove(document_type_id);
     } catch (err) {

--- a/backend/src/document_data/document_data.service.ts
+++ b/backend/src/document_data/document_data.service.ts
@@ -452,4 +452,10 @@ export class DocumentDataService {
       return { deleted: false, message: err.message };
     }
   }
+
+  async removeByDocTypeId(document_type_id: number) {
+    return this.documentDataRepository.delete({
+      document_type: { id: document_type_id },
+    });
+  }
 }

--- a/backend/src/document_template/document_template.service.ts
+++ b/backend/src/document_template/document_template.service.ts
@@ -141,6 +141,10 @@ export class DocumentTemplateService {
     return { id: 0 };
   }
 
+  async removeByDocTypeId(document_type_id: number): Promise<void> {
+    await this.documentTemplateRepository.delete({ document_type: { id: document_type_id } });
+  }
+
   async findAll(document_type_id: number): Promise<DocumentTemplate[]> {
     return this.documentTemplateRepository.find({
       where: { is_deleted: false, document_type: { id: document_type_id } },

--- a/backend/src/document_type/document_type.service.ts
+++ b/backend/src/document_type/document_type.service.ts
@@ -127,6 +127,10 @@ export class DocumentTypeService {
     }
   }
 
+  async removeProvisionGroupByDocTypeId(document_type_id: number) {
+    return this.provisionGroupRepository.delete({ document_type: { id: document_type_id } });
+  }
+
   async updateGroupMaximums(provision_group: number, max: number, provision_group_text: string) {
     let provisionGroup: ProvisionGroup = await this.provisionGroupRepository.findOneBy({
       provision_group: provision_group,


### PR DESCRIPTION
- Delete provision groups, templates, and document data when deleting a document type.