### PR TITLE
TICDI-117/118

### DIFF
--- a/backend/src/report/report.service.ts
+++ b/backend/src/report/report.service.ts
@@ -415,7 +415,7 @@ export class ReportService {
         mailing_country_code: tenantAddr ? tenantAddr.countryCd : '',
         mailing_country: tenantAddr ? tenantAddr.country : '',
         location_description: rawData.locLand,
-        tenure: tenure ? JSON.stringify(tenure) : '',
+        tenure: tenure ? tenure : '',
       };
       data = {
         DTID: mappedData.dtid,

--- a/frontend/src/app/content/pages/LandingPage.tsx
+++ b/frontend/src/app/content/pages/LandingPage.tsx
@@ -261,7 +261,7 @@ const LandingPage: FC = () => {
   const validateProvisions = (): string | null => {
     const mandatoryGroups: number[] = [];
     for (let p of provisions) {
-      if (p.type === 'M' && !mandatoryGroups.includes(p.provision_group.provision_group)) {
+      if (p.type === 'M' && p.provision_group && !mandatoryGroups.includes(p.provision_group.provision_group)) {
         mandatoryGroups.push(p.provision_group.provision_group);
       }
     }


### PR DESCRIPTION
- Null provision group for mandatory provision wasn't being handled properly on the generate document page
- Tenure object in LUR report was being stringified, this previously worked but now it doesn't. Removing the string conversion fixed the issue